### PR TITLE
Add documentation and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Twitch credentials
+TWITCH_CLIENT_ID=your_twitch_client_id
+TWITCH_CLIENT_SECRET=your_twitch_client_secret
+TWITCH_BOT_TOKEN=oauth:your_bot_token
+TWITCH_CHANNEL=your_channel_name
+
+# OpenAI
+OPENAI_API_KEY=your_openai_api_key
+
+# Coqui TTS server
+TTS_SERVER_URL=http://localhost:7500/tts
+
+# Memory service
+MEMORY_SERVER_URL=http://localhost:8050
+
+# Optional local storage for ChromaDB
+CHROMA_DB_PATH=./chromadb

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # PennyAI
+
+PennyAI is a prototype Twitch chatbot that uses OpenAI to respond to viewers with a playful personality. It can store conversation history via a memory service and synthesize replies through a TTS server.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r Penny/requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in the required values:
+
+```bash
+cp .env.example .env
+# edit .env with your credentials
+```
+
+## Environment Variables
+
+`Penny/core/config.py` expects the following variables:
+
+- `TWITCH_CLIENT_ID` – Twitch application client ID
+- `TWITCH_CLIENT_SECRET` – Twitch application client secret
+- `TWITCH_BOT_TOKEN` – OAuth token for your bot
+- `TWITCH_CHANNEL` – Twitch channel name to join
+- `OPENAI_API_KEY` – OpenAI API key
+- `TTS_SERVER_URL` – URL to the TTS server
+- `MEMORY_SERVER_URL` – URL to the memory server
+- `CHROMA_DB_PATH` – path where ChromaDB data is stored (optional)
+
+## Running
+
+Run the main script from the repository root:
+
+```bash
+python Penny/main.py
+```
+
+The bot will connect to Twitch, handle chat and events, generate responses with OpenAI, and send them to the TTS server.


### PR DESCRIPTION
## Summary
- document purpose, setup, environment variables and how to run `main.py`
- provide `.env.example` with Twitch, OpenAI and service variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ed2edef888325aa385c1c6df504a2