### PR TITLE
Fix OpenAI service async reply logic

### DIFF
--- a/Penny/services/openai_service.py
+++ b/Penny/services/openai_service.py
@@ -5,6 +5,10 @@ from services.memory_service import MemoryService
 import openai
 
 import asyncio
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIService:
@@ -16,44 +20,47 @@ class OpenAIService:
         self.event_bus.subscribe("chat_message", self.generate_reply)
         self.event_bus.subscribe("twitch_event", self.generate_event_reply)
 
-
     async def generate_reply(self, chat_message: ChatMessage):
-        context = await asyncio.to_thread(self.memory_service.query, chat_message.message)
-    def generate_reply(self, chat_message: ChatMessage):
-        context = self.memory_service.query(chat_message.message)
-        history = " ".join(item.get("text", "") for item in context.get("results", []))
-
-        system_prompt = (
-            "You are Penny, a sassy, sometimes rude, self-aware AI who believes"
-            " she is a real person streaming on Twitch. Respond in short, lively"
-            " sentences and keep the attitude playful."
-        )
-
-        messages = [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": f"{chat_message.user}: {chat_message.message}"},
-        ]
-        if history:
-            messages.append({"role": "system", "content": f"Memory context: {history}"})
-
+        """Generate a reply to a chat message using OpenAI."""
         try:
-            resp = await asyncio.to_thread(openai.ChatCompletion.create, model="gpt-3.5-turbo", messages=messages)
+            context = await asyncio.to_thread(
+                self.memory_service.query, chat_message.message
+            )
+            history = " ".join(
+                item.get("text", "") for item in context.get("results", [])
+            )
+
+            system_prompt = (
+                "You are Penny, a sassy, sometimes rude, self-aware AI who believes"
+                " she is a real person streaming on Twitch. Respond in short, lively"
+                " sentences and keep the attitude playful."
+            )
+
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {
+                    "role": "user",
+                    "content": f"{chat_message.user}: {chat_message.message}",
+                },
+            ]
+            if history:
+                messages.append(
+                    {"role": "system", "content": f"Memory context: {history}"}
+                )
+
+            resp = await asyncio.to_thread(
+                openai.ChatCompletion.create,
+                model="gpt-3.5-turbo",
+                messages=messages,
+            )
             text = resp.choices[0].message.content.strip()
             self.event_bus.publish("penny_response", PennyResponse(text=text))
             self.event_bus.publish("chat_reply", text)
-        except Exception as e:
-            print(f"OpenAI request failed: {e}")
+        except Exception:
+            logger.exception("OpenAI request failed")
 
     async def generate_event_reply(self, event):
-
-            resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
-            text = resp.choices[0].message.content.strip()
-            self.event_bus.publish("penny_response", PennyResponse(text=text))
-        except Exception as e:
-            print(f"OpenAI request failed: {e}")
-
-    def generate_event_reply(self, event):
-
+        """Create a chat message from an event and generate a reply."""
         event_desc = event.type.replace("_", " ")
         msg = ChatMessage(
             user="twitch",
@@ -61,5 +68,4 @@ class OpenAIService:
             timestamp=datetime.utcnow(),
         )
         await self.generate_reply(msg)
-        self.generate_reply(msg)
 


### PR DESCRIPTION
## Summary
- consolidate duplicate methods in `openai_service.py`
- implement a single async `generate_reply`
- add async `generate_event_reply`
- log exceptions using Python logging

## Testing
- `python -m py_compile Penny/services/openai_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686ed474b254832591b4f9b7d8058aa5