### PR TITLE
Fix EventSubService start method

### DIFF
--- a/Penny/services/eventsub_service.py
+++ b/Penny/services/eventsub_service.py
@@ -58,7 +58,4 @@ class EventSubService:
 
     async def _on_hype_end(self, data):
         await self._dispatch("hype_train_end", data)
-        def start(self):
-        # placeholder for Twitch EventSub integration
-        print("EventSubService started - listening for events")
 


### PR DESCRIPTION
## Summary
- remove unused sync `start` placeholder from `EventSubService`
- keep the async `start` method as the only implementation

## Testing
- `python -m compileall -q Penny`

------
https://chatgpt.com/codex/tasks/task_e_686ed77ea5b48325b1fa5f467d5a4ca0