### PR TITLE
Fix duplicate import in memory_service

### DIFF
--- a/Penny/services/memory_service.py
+++ b/Penny/services/memory_service.py
@@ -1,6 +1,5 @@
 from core.event_bus import EventBus
 from models.event_models import ChatMessage, PennyResponse
-from models.event_models import ChatMessage
 
 import requests
 


### PR DESCRIPTION
## Summary
- clean up extra ChatMessage import in `memory_service.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ed8b874748325b5be3e121bc54214