### PR TITLE
Pin dependency versions

### DIFF
--- a/Penny/requirements.txt
+++ b/Penny/requirements.txt
@@ -1,19 +1,19 @@
 # Core dependencies
-pydantic
-pydantic-settings
+pydantic==2.7.1
+pydantic-settings==2.2.1
 
 # Twitch
-twitchio
-twitchAPI
+twitchio==2.7.1
+twitchAPI==2.7.0
 
 # OpenAI client
-openai
+openai==1.10.0
 
 # Vector database
-chromadb
+chromadb==0.4.22
 
 # Environment variable loader
-python-dotenv
+python-dotenv==1.0.1
 
 # HTTP requests
-requests
+requests==2.31.0


### PR DESCRIPTION
## Summary
- lock versions in Penny/requirements.txt for reproducible installs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686ed94063b88325b1c8042e6375d168