### PR TITLE
Add basic tests for EventBus and QueueService

### DIFF
--- a/Penny/requirements.txt
+++ b/Penny/requirements.txt
@@ -17,3 +17,6 @@ python-dotenv==1.0.1
 
 # HTTP requests
 requests==2.31.0
+
+# Testing
+pytest==8.1.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# Add the Penny directory to sys.path so tests can import project modules
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'Penny'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# Provide a minimal pydantic stub so tests can run without installing the
+# external dependency. Only the small subset needed for these tests is
+# implemented.
+import types
+if 'pydantic' not in sys.modules:
+    pydantic_stub = types.ModuleType('pydantic')
+
+    class BaseModel:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    pydantic_stub.BaseModel = BaseModel
+    sys.modules['pydantic'] = pydantic_stub

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from core.event_bus import EventBus
+
+
+def test_event_bus_publish_and_receive():
+    bus = EventBus()
+    received_sync = []
+    received_async = []
+
+    def sync_callback(data):
+        received_sync.append(data)
+
+    async def async_callback(data):
+        received_async.append(data)
+
+    async def run_test():
+        bus.subscribe("sync_event", sync_callback)
+        bus.subscribe("async_event", async_callback)
+
+        bus.publish("sync_event", "hello")
+        bus.publish("async_event", "world")
+
+        await asyncio.sleep(0)
+
+    asyncio.run(run_test())
+
+    assert received_sync == ["hello"]
+    assert received_async == ["world"]

--- a/tests/test_queue_service.py
+++ b/tests/test_queue_service.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from core.event_bus import EventBus
+from services.queue_service import QueueService
+from models.event_models import PennyResponse
+
+
+def test_queue_service_processes_responses_sequentially():
+    bus = EventBus()
+    queue = QueueService(bus)
+
+    spoken = []
+
+    def on_speak(response: PennyResponse):
+        spoken.append(response.text)
+
+    async def run_test():
+        bus.subscribe("speak", on_speak)
+
+        first = PennyResponse(text="first")
+        second = PennyResponse(text="second")
+
+        bus.publish("penny_response", first)
+        bus.publish("penny_response", second)
+
+        await asyncio.sleep(0.01)
+
+    asyncio.run(run_test())
+
+    assert spoken == ["first", "second"]


### PR DESCRIPTION
## Summary
- add pytest to requirements
- provide a small pydantic stub for tests
- add tests verifying EventBus behavior
- add tests verifying QueueService sequential processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eda0e7d808325b81488e30b502c77